### PR TITLE
Remove leftover references to Compass 🤦‍

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG NODE_ENV=development
 ENV RACK_ENV=$RUBY_ENV \
     NODE_ENV=$NODE_ENV
 
-ENV APP_HOME=/compass \
+ENV APP_HOME=/jekyll-template \
     PORT=4000
 
 ENV BUNDLE_GEMFILE=$APP_HOME/Gemfile \

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This template offers rich development experience using the following technologie
 
 ### Using Docker
 
-This is the fastest way to get started working on Compass:
+This is the fastest way to get started working on Jekyll:
 
 * Rename the env file `.env.sample` to `.env` and add the required environment variables
 
@@ -142,7 +142,7 @@ Corresponding to the following file structure:
 
 This script deploys both the public and internal sites.
 
-> .env.docker is used to load the environment variables from the local environment `docker run --rm --entrypoint '/bin/bash' --env-file .env.docker -it compass`
+> .env.docker is used to load the environment variables from the local environment `docker run --rm --entrypoint '/bin/bash' --env-file .env.docker -it jekyll-template`
 
 ## Troubleshooting
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,7 +1,7 @@
 <title>{{ site.name }} | {% if page.parent %}{{ page.parent | capitalize }} | {% endif %}{{ page.title }}</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="apple-mobile-web-app-title" content="Compass"/>
+<meta name="apple-mobile-web-app-title" content="Jekyll Template"/>
 <meta name="mobile-web-app-capable" content="yes"/>
 <meta name="apple-touch-fullscreen" content="yes"/>
 <meta name="apple-mobile-web-app-status-bar-style" content="#1b79ea"/>


### PR DESCRIPTION
## What happened

Replaced references to Compass by Jekyll Template across the template. 
 
## Proof Of Work

Text search for Compass yields no results 👍 

![jekyll-templates___volumes_workspace_jekyll-templates__-_____bin_start__jekyll-templates_](https://user-images.githubusercontent.com/696529/48255410-2931c400-e43f-11e8-8a7a-e5453e42c40e.png)
