### PR TITLE
Improve Jekyll configuration defaults

### DIFF
--- a/_plugins/environment_variables.rb
+++ b/_plugins/environment_variables.rb
@@ -1,0 +1,15 @@
+# Plugin to add environment variables to the `site` object in Liquid templates
+require 'dotenv'
+
+module Jekyll
+  class EnvironmentVariablesGenerator < Generator
+    priority :highest
+
+    def generate(site)
+      site.config['env'] = Dotenv.load
+
+      Jekyll.logger.info 'Dotenv variables: '
+      Jekyll.logger.info site.config['env'].to_yaml
+    end
+  end
+end

--- a/config/jekyll.yml
+++ b/config/jekyll.yml
@@ -14,6 +14,7 @@ sass:
 
 kramdown:
   input: GFM
+  parse_block_html: true
 
 collections:
   pages:

--- a/config/jekyll.yml
+++ b/config/jekyll.yml
@@ -46,7 +46,9 @@ exclude:
   - Dockerfile
   - Gemfile
   - Gemfile.lock
+  - LICENSE
   - package.json
   - package-lock.json
   - Procfile.dev
   - README.md
+  - Rakefile

--- a/config/jekyll.yml
+++ b/config/jekyll.yml
@@ -15,8 +15,10 @@ sass:
   style: compressed
 
 kramdown:
+  # All config options: https://jekyllrb.com/docs/configuration/markdown/
   input: GFM
   parse_block_html: true
+  auto_ids: false
 
 collections:
   pages:

--- a/config/jekyll.yml
+++ b/config/jekyll.yml
@@ -5,7 +5,9 @@ permalink: pretty
 relative_permalinks: false
 timezone: Etc/UTC
 
-safe: true
+# Required to use local plugins
+safe: false
+
 lsi: false
 markdown: kramdown
 


### PR DESCRIPTION
## What happened

Bring the latest configuration improvements from our latest Jekyll-based projects:

* Parsing of markdown within HTML elements

![nimblehq-web___volumes_workspace_nimblehq-web__-_____index_md__nimblehq-web_](https://user-images.githubusercontent.com/696529/48308517-6e6a0900-e599-11e8-9061-b2188b6dfd92.png)

* Access of environment variables within Liquid templates:

![nimblehq-web___volumes_workspace_nimblehq-web__-______includes_analytics_html__nimblehq-web_](https://user-images.githubusercontent.com/696529/48308520-8b9ed780-e599-11e8-87b3-acb83a14a07a.png)


* Disabling of element IDs generation: for a static site, it's a better default to keep HTML lean
 
## Insight

Environment variables added to `.env` can be checked in the console. This is great for debugging purposes:

![jekyll-templates___volumes_workspace_jekyll-templates__-_____config_jekyll_yml__jekyll-templates_](https://user-images.githubusercontent.com/696529/48308505-3bc01080-e599-11e8-9512-ea85c7339498.png)