### PR TITLE
Simplify footer and header navigation

### DIFF
--- a/_data/menu/footer.yml
+++ b/_data/menu/footer.yml
@@ -1,5 +1,6 @@
 - title: Home
+  permalink: /
 - title: About
-  slug: about
+  permalink: /about
 - title: Contact Us
-  slug: contact-us
+  permalink: /contact

--- a/_data/menu/header.yml
+++ b/_data/menu/header.yml
@@ -1,5 +1,7 @@
 - title: Home
+  permalink: /
 - title: About
-  slug: about
+  permalink: /about
   sub_pages:
-  - team
+  - title: Team
+    permalink: /team

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,16 +1,11 @@
 <footer class="app-footer">
   <nav class='secondary-navigation'>
     <ul class="secondary-navigation__list">
-      {% for section in site.data.menu.footer %}
-      {% if section.slug %}
-        {% assign section_url = '/pages/' | append: section.slug | append: '/' %}
-      {% else %}
-        {% assign section_url = '/' %}
-      {% endif %}
+    {% for section in site.data.menu.footer %}
       <li class="secondary-navigation__list-item{% if section_url == page.url %} secondary-navigation__list-item--active{% endif %}">
-        <a href="{{ section_url }}">{{ section.title }}</a>
+        <a href="{{ section.permalink }}">{{ section.title }}</a>
       </li>
-      {% endfor %}
+    {% endfor %}
     </ul>
   </nav>
 </footer>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,30 +3,21 @@
 
   <nav class='app-navigation'>
     <ul class="app-navigation__list">
-      {% for section in site.data.menu.header %}
-      {% if section.slug %}
-        {% assign section_url = '/pages/' | append: section.slug | append: '/' %}
-      {% else %}
-        {% assign section_url = '/' %}
-      {% endif %}
+    {% for section in site.data.menu.header %}
       <li class="app-navigation__list-item{% if section_url == page.url %} app-navigation__list-item--active{% endif %}">
-        <a href="{{ section_url }}">{{ section.title }}</a>
+        <a href="{{ section.permalink }}">{{ section.title }}</a>
         {% if section.sub_pages %}
         <ul class="app-navigation__sub-list">
-          {% for sub_page in section.sub_pages %}
-            {% assign sub_page_url = sub_page | prepend: section_url | append: '/' %}
-            {% for content_page in site.pages %}
-              {% if content_page.url == sub_page_url %}
-              <li class="app-navigation__sub-list-item{% if sub_page_url == page.url %} app-navigation__sub-list-item--active{% endif %}">
-                <a href="{{ sub_page_url }}">{{ content_page.title }}</a>
-              </li>
-              {% endif %}
-            {% endfor %}
-          {% endfor %}
+        {% for sub_page in section.sub_pages %}
+          {% assign sub_page_url = section.permalink | append: sub_page.permalink %}
+          <li class="app-navigation__sub-list-item{% if sub_page_url == page.url %} app-navigation__sub-list-item--active{% endif %}">
+            <a href="{{ sub_page_url }}">{{ sub_page.title }}</a>
+          </li>
+        {% endfor %}
         </ul>
         {% endif %}
       </li>
-      {% endfor %}
+    {% endfor %}
     </ul>
   </nav>
 </header>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,6 +1,7 @@
 ---
 id: about
 title: About
+permalink: /about
 ---
 
 ## Why Jekyll?

--- a/_pages/about/team.md
+++ b/_pages/about/team.md
@@ -1,6 +1,7 @@
 ---
 id: about-team
 title: Team
+permalink: /about/team
 parent: about
 ---
 

--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -1,6 +1,7 @@
 ---
-id: contact-us
+id: contact
 title: Contact
+permalink: /contact
 ---
 
 ## Contact Jekyll


### PR DESCRIPTION
## What happened

Revisit the way the header and footer navigation was generated.
 
## Insight

The previous implementation came from a need in our knowledge base (our first Jekyll-based static site) to only show the pages with content. It was complex while we can just rely on defining a permalink in front matter.
 
## Proof Of Work

![jekyll](https://user-images.githubusercontent.com/696529/48309625-f576ab80-e5b0-11e8-9e4a-15cdb58186e7.gif)
