### PR TITLE
Restructure page titles for SEO purposes

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,4 +1,4 @@
-{% capture parent_page_title %}{% if page.parent %}{{ page.parent | capitalize }} | {% endif %}{% endcapture %}
+{% capture parent_page_title %}{% if page.parent %}{{ page.parent | capitalize | prepend: ' | ' }}{% endif %}{% endcapture %}
 {% capture meta_title %}{{ page.title | append: parent_page_title | append: ' | ' | append: site.name }}{% endcapture %}
 {% capture meta_description %}{% if page.seo.description %}{{ page.seo.description }}{% else %}{{ site.seo.description }}{% endif %}{% endcapture %}
 {% capture meta_image %}{% if page.seo.image %}{{ page.seo.image }}{% else %}{{ site.seo.image }}{% endif %}{% endcapture %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,5 +1,5 @@
 {% capture parent_page_title %}{% if page.parent %}{{ page.parent | capitalize }} | {% endif %}{% endcapture %}
-{% capture meta_title %}{{ site.name | append: ' | ' | append: parent_page_title | append: page.title }}{% endcapture %}
+{% capture meta_title %}{{ page.title | append: parent_page_title | append: ' | ' | append: site.name }}{% endcapture %}
 {% capture meta_description %}{% if page.seo.description %}{{ page.seo.description }}{% else %}{{ site.seo.description }}{% endif %}{% endcapture %}
 {% capture meta_image %}{% if page.seo.image %}{{ page.seo.image }}{% else %}{{ site.seo.image }}{% endif %}{% endcapture %}
 <title>{{ meta_title }}</title>


### PR DESCRIPTION
https://github.com/nimblehq/jekyll-templates/projects/1#card-52937439

## What happened

Move the site name at the end of the generated page title.

Closes #32 
 
## Insight

`N/A`
 
## Proof Of Work

For pages at the root level:

![Screen Shot 2564-05-02 at 08 59 04](https://user-images.githubusercontent.com/696529/116799741-2baf9900-ab25-11eb-9566-34f46b520adb.png)

For nested pages (which have a parent page):

![Screen Shot 2564-05-02 at 09 00 42](https://user-images.githubusercontent.com/696529/116805023-a2608c80-ab4d-11eb-8d66-8a3f971965fa.png)
